### PR TITLE
Changing from SecKeyConvertible to SecKeyRepresentable

### DIFF
--- a/Sources/SwiftSecurity/Keychain/Keychain.swift
+++ b/Sources/SwiftSecurity/Keychain/Keychain.swift
@@ -312,11 +312,11 @@ extension Keychain {
 // MARK: - SecKey
 
 extension Keychain: SecKeyStore {
-    public func store<T: SecKeyConvertible>(_ key: T, query: SecItemQuery<SecKey>, accessPolicy: AccessPolicy = .default) throws {
+    public func store<T: SecKeyRepresentable>(_ key: T, query: SecItemQuery<SecKey>, accessPolicy: AccessPolicy = .default) throws {
         _ = try store(key, returning: [], query: query, accessPolicy: accessPolicy)
     }
     
-    public func store<T: SecKeyConvertible>(
+    public func store<T: SecKeyRepresentable>(
         _ key: T,
         returning returnType: SecReturnType,
         query: SecItemQuery<SecKey>,
@@ -334,7 +334,7 @@ extension Keychain: SecKeyStore {
         return try store(.reference(key.secKey), returning: returnType, query: query, accessPolicy: accessPolicy)
     }
 
-    public func retrieve<T: SecKeyConvertible>(_ query: SecItemQuery<SecKey>, authenticationContext: LAContext? = nil) throws -> T? {
+    public func retrieve<T: SecKeyRepresentable>(_ query: SecItemQuery<SecKey>, authenticationContext: LAContext? = nil) throws -> T? {
         guard
             let value = try retrieve(.reference, query: query, authenticationContext: authenticationContext),
             case let .reference(secKey) = value

--- a/Sources/SwiftSecurity/Keychain/SecItemStore/SecItemStore.swift
+++ b/Sources/SwiftSecurity/Keychain/SecItemStore/SecItemStore.swift
@@ -178,7 +178,7 @@ public protocol SecKeyStore: SecItemStore {
     ///   - data: The key.
     ///   - query: An object that describes the search. See ``SecItemQuery<SecKey>``.
     ///   - accessPolicy: The protection policy to use when creating the associated access control object.
-    func store<T: SecKeyConvertible>(_ key: T, query: SecItemQuery<SecKey>, accessPolicy: AccessPolicy) throws
+    func store<T: SecKeyRepresentable>(_ key: T, query: SecItemQuery<SecKey>, accessPolicy: AccessPolicy) throws
     
     /// Stores the key with specified query.
     /// - Parameters:
@@ -188,7 +188,7 @@ public protocol SecKeyStore: SecItemStore {
     ///   - query: An object that describes the query. See ``SecItemQuery<SecKey>``.
     ///   - accessPolicy: The protection policy to use when creating the associated access control object.
     /// - Returns: On return, the result. The exact value of the result depends on the return type values supplied as `returnType`.
-    func store<T: SecKeyConvertible>(
+    func store<T: SecKeyRepresentable>(
         _ key: T,
         returning returnType: SecReturnType,
         query: SecItemQuery<SecKey>,
@@ -200,7 +200,7 @@ public protocol SecKeyStore: SecItemStore {
     ///   - query: An object that describes the query. See ``SecItemQuery<SecKey>``.
     ///   - authenticationContext: A local authentication context.
     /// - Returns: On return, the first found key.
-    func retrieve<T: SecKeyConvertible>(_ query: SecItemQuery<SecKey>, authenticationContext: LAContext?) throws -> T?
+    func retrieve<T: SecKeyRepresentable>(_ query: SecItemQuery<SecKey>, authenticationContext: LAContext?) throws -> T?
 }
 
 // MARK: - SecCertificate


### PR DESCRIPTION
This change makes adding support for RSA keys even easier.  It seems like it might have been the original intent, and hope it helps